### PR TITLE
Chore/update for 1.21 and fix warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar
+
+# Eclipse m2e generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+# VSCode settings
+.vscode/

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
     </properties>
 
     <build>
@@ -24,8 +24,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.21-R0.1-SNAPSHOT</version>
+            <version>1.19.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.18-rc3-R0.1-SNAPSHOT</version>
+            <version>1.21-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -159,6 +159,16 @@
             <artifactId>SpigotUpdateChecker</artifactId>
             <version>1.3.0</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.16.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.12.0</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>11</java.version>
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <build>
@@ -22,16 +22,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.13.0</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.4.2</version>
                 <configuration>
                     <finalName>BestTools-${project.version}</finalName>
                 </configuration>
@@ -39,11 +39,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.6.0</version>
                 <configuration>
                     <relocations>
                         <relocation>
-                            <pattern>de.jeff_media.updatechecker</pattern>
+                            <pattern>com.jeff_media.updatechecker</pattern>
                             <shadedPattern>de.jeff_media.BestTools.updatechecker</shadedPattern>
                         </relocation>
                         <relocation>
@@ -78,13 +78,13 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
-        <extensions>
+        <!-- <extensions>
             <extension>
                 <groupId>org.apache.maven.wagon</groupId>
                 <artifactId>wagon-ftp</artifactId>
                 <version>3.4.1</version>
             </extension>
-        </extensions>
+        </extensions> -->
 
     </build>
 
@@ -99,11 +99,11 @@
         </repository>
         <repository>
             <id>CodeMC</id>
-            <url>https://repo.codemc.org/repository/maven-public</url>
+            <url>https://repo.codemc.org/repository/maven-public/</url>
         </repository>
         <repository>
-            <id>jeff-media-gbr</id>
-            <url>https://hub.jeff-media.de/nexus/repository/jeff-media-public/</url>
+            <id>jeff-media-public</id>
+            <url>https://repo.jeff-media.com/public/</url>
         </repository>
         <repository>
             <id>enginehub-repo</id>
@@ -115,50 +115,46 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.10.9</version>
+            <version>2.11.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.19.4-R0.1-SNAPSHOT</version>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.sk89q.worldguard</groupId>
             <artifactId>worldguard-bukkit</artifactId>
-            <version>7.0.4</version>
+            <version>7.0.10</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.sk89q.worldedit</groupId>
             <artifactId>worldedit-bukkit</artifactId>
-            <version>7.2.0-SNAPSHOT</version>
+            <version>7.3.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
-            <scope>provided</scope>
+            <version>1.18.34</version>
         </dependency>
         <dependency>
-            <groupId>com.jeff_media</groupId>
+            <groupId>com.jeff-media</groupId>
             <artifactId>MorePersistentDataTypes</artifactId>
-            <version>1.1.0</version>
-            <scope>compile</scope>
+            <version>2.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>1.7</version>
-            <scope>compile</scope>
+            <version>3.0.2</version>
         </dependency>
         <dependency>
-            <groupId>de.jeff_media</groupId>
+            <groupId>com.jeff_media</groupId>
             <artifactId>SpigotUpdateChecker</artifactId>
-            <version>1.3.0</version>
-            <scope>compile</scope>
+            <version>3.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>8</maven.compiler.release>
+        <maven.compiler.release>11</maven.compiler.release>
     </properties>
 
     <build>
@@ -24,8 +24,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,6 @@
     <groupId>de.jeff_media</groupId>
     <artifactId>BestTools</artifactId>
     <name>BestTools</name>
-    <!--<url>https://www.chestsort.de</url>-->
     <description>Automatically switches to the best tools. Most efficient Auto-Tool plugin!</description>
     <version>2.2.1</version>
     <packaging>jar</packaging>
@@ -78,14 +77,6 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
-        <!-- <extensions>
-            <extension>
-                <groupId>org.apache.maven.wagon</groupId>
-                <artifactId>wagon-ftp</artifactId>
-                <version>3.4.1</version>
-            </extension>
-        </extensions> -->
-
     </build>
 
     <repositories>

--- a/src/main/java/de/jeff_media/BestTools/BestToolsHandler.java
+++ b/src/main/java/de/jeff_media/BestTools/BestToolsHandler.java
@@ -2,7 +2,6 @@ package de.jeff_media.BestTools;
 
 import org.bukkit.Material;
 import org.bukkit.Tag;
-import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -199,7 +198,7 @@ public class BestToolsHandler {
     boolean hasSilktouch(ItemStack item) {
         if(item==null) return false;
         if(!item.hasItemMeta()) return false;
-        return item.getItemMeta().hasEnchant(Enchantment.SILK_TOUCH);
+        return item.getItemMeta().hasEnchant(EnchantmentUtils.getSilkTouch());
     }
 
     @Nullable

--- a/src/main/java/de/jeff_media/BestTools/BestToolsHandler.java
+++ b/src/main/java/de/jeff_media/BestTools/BestToolsHandler.java
@@ -13,7 +13,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -130,6 +129,7 @@ public class BestToolsHandler {
 
     // TODO: Optimize all of this by caching valid Materials instead of doing String checks everytime
 
+    @SuppressWarnings("incomplete-switch")
     boolean profitsFromSilkTouch(Material mat) {
         String name = mat.name();
         switch(mat) {

--- a/src/main/java/de/jeff_media/BestTools/BestToolsHandler.java
+++ b/src/main/java/de/jeff_media/BestTools/BestToolsHandler.java
@@ -104,15 +104,15 @@ public class BestToolsHandler {
      * @param item
      * @return Durability left, or -1 if not damageable
      */
-    private int getDurability(@Nullable ItemStack item) {
-        // TODO: Delete? Its unused
-        if(item==null) return -1;
-        if(!(item.getItemMeta() instanceof Damageable)) {
-            return -1;
-        }
-        Damageable damageable = (Damageable) item.getItemMeta();
-        return item.getType().getMaxDurability() - damageable.getDamage();
-    }
+    // private int getDurability(@Nullable ItemStack item) {
+    //     // TODO: Delete? Its unused
+    //     if(item==null) return -1;
+    //     if(!(item.getItemMeta() instanceof Damageable)) {
+    //         return -1;
+    //     }
+    //     Damageable damageable = (Damageable) item.getItemMeta();
+    //     return item.getType().getMaxDurability() - damageable.getDamage();
+    // }
 
     /**
      * Gets the best tool type for a material

--- a/src/main/java/de/jeff_media/BestTools/BestToolsHandler.java
+++ b/src/main/java/de/jeff_media/BestTools/BestToolsHandler.java
@@ -144,6 +144,7 @@ public class BestToolsHandler {
         return false;
     }
 
+    // TODO: Implement profitsFromFortune()
 
     boolean isTool(Tool tool, ItemStack item) {
         Material m = item.getType();

--- a/src/main/java/de/jeff_media/BestTools/BestToolsHandler.java
+++ b/src/main/java/de/jeff_media/BestTools/BestToolsHandler.java
@@ -199,7 +199,7 @@ public class BestToolsHandler {
     boolean hasSilktouch(ItemStack item) {
         if(item==null) return false;
         if(!item.hasItemMeta()) return false;
-        return item.getItemMeta().hasEnchant(EnchantmentUtils.getSilkTouch());
+        return item.getItemMeta().hasEnchant(EnchantmentUtils.getEnchantment("silk_touch"));
     }
 
     @Nullable

--- a/src/main/java/de/jeff_media/BestTools/BestToolsListener.java
+++ b/src/main/java/de/jeff_media/BestTools/BestToolsListener.java
@@ -16,10 +16,8 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
-import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
-import org.bukkit.plugin.RegisteredListener;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;

--- a/src/main/java/de/jeff_media/BestTools/BestToolsUtils.java
+++ b/src/main/java/de/jeff_media/BestTools/BestToolsUtils.java
@@ -553,6 +553,7 @@ public class BestToolsUtils {
 
         }
 
+        // This is fairly expensive, but 2ms vs 8ms isn't a meaningful difference.
         try {
             tagToMap(Tag.MINEABLE_AXE, Tool.AXE);
             tagToMap(Tag.MINEABLE_HOE, Tool.HOE);
@@ -570,6 +571,7 @@ public class BestToolsUtils {
     }
 
     // F****** Spigot API is not "forward compatible" with new Material enums
+    // TODO: I believe we can avoid compatibility issues by using Registry<Material>
     private void initFallbackMaterials() {
 
         for (Material mat : Material.values()) {

--- a/src/main/java/de/jeff_media/BestTools/BestToolsUtils.java
+++ b/src/main/java/de/jeff_media/BestTools/BestToolsUtils.java
@@ -2,6 +2,7 @@ package de.jeff_media.BestTools;
 
 import de.jeff_media.BestTools.BestToolsHandler.Tool;
 import de.jeff_media.BestTools.tags.v1_17;
+
 import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.jetbrains.annotations.NotNull;
@@ -17,7 +18,7 @@ import java.util.Objects;
 public class BestToolsUtils {
 
     final String[] wood = {"BIRCH", "ACACIA", "OAK", "DARK_OAK", "SPRUCE", "JUNGLE"}; // Crimson and Warped stems are not needed, this is only for old versions
-    final String[] weapons = {"BOW", "CROSSBOW", "TRIDENT", "NETHERITE_SWORD", "DIAMOND_SWORD", "GOLDEN_SWORD", "IRON_SWORD", "STONE_SWORD", "WOODEN_SWORD"};
+    final String[] weapons = {"BOW", "CROSSBOW", "TRIDENT", "NETHERITE_SWORD", "DIAMOND_SWORD", "GOLDEN_SWORD", "IRON_SWORD", "STONE_SWORD", "WOODEN_SWORD", "MACE"};
     final String[] instaBreakableByHand = {"COMPARATOR", "REPEATER", "REDSTONE_WIRE", "REDSTONE_TORCH", "REDSTONE_WALL_TORCH", "TORCH", "SOUL_TORCH", "WALL_TORCH", "SOUL_WALL_TORCH",
             "SCAFFOLDING", "SLIME_BLOCK", "HONEY_BLOCK", "TNT", "TRIPWIRE", "TRIPWIRE_HOOK", "GRASS", "SUGAR_CANE", "LILY_PAD",
             "OAK_SAPLING", "SPRUCE_SAPLING", "BIRCH_SAPLING", "JUNGLE_SAPLING", "ACACIA_SAPLING", "DARK_OAK_SAPLING",
@@ -114,7 +115,6 @@ public class BestToolsUtils {
             addToMap(s, main.toolHandler.swords);
         }
 
-
         main.toolHandler.allTools.addAll(Arrays.asList(defaultMats));
         for (String s : netheriteTools) {
             if (Material.getMaterial(s) != null) {
@@ -122,14 +122,7 @@ public class BestToolsUtils {
             }
         }
 
-        // 1.17+
-        try {
-            for (Material mat : v1_17.getPickaxeMaterials()) {
-                addToMap(mat, Tool.PICKAXE);
-            }
-        } catch (Throwable t) {
-            // 1.17+
-        }
+        this.initMap();
 
         //uToolMap = Map.copyOf(main.toolHandler.toolMap); // Java 10+ only
     }
@@ -338,7 +331,6 @@ public class BestToolsUtils {
         addToMap("ANDESITE", Tool.PICKAXE);
         addToMap("BAMBOO", Tool.AXE);
         addToMap("BAMBOO_SAPLING", Tool.AXE);
-        addToMap("BASALT", Tool.PICKAXE);
         addToMap("BIRCH_BUTTON", Tool.AXE);
         addToMap("BIRCH_FENCE", Tool.AXE);
         addToMap("BIRCH_FENCE_GATE", Tool.AXE);
@@ -537,7 +529,6 @@ public class BestToolsUtils {
         // 1.17
         try {
             for (Material mat : Material.values()) {
-
                 if (mat.name().contains("AMETHYST")) {
                     addToMap(mat.name(), Tool.PICKAXE);
                 }
@@ -551,10 +542,23 @@ public class BestToolsUtils {
                     addToMap(mat.name(), Tool.PICKAXE);
                 }
             }
+
+            for (Material mat : v1_17.getPickaxeMaterials()) {
+                addToMap(mat, Tool.PICKAXE);
+            }
+
             addToMap(Material.GLOW_LICHEN, Tool.SHEARS);
             addToMap(Material.CALCITE, Tool.PICKAXE);
         } catch (Throwable ignored) {
 
+        }
+
+        try {
+            tagToMap(Tag.MINEABLE_AXE, Tool.AXE);
+            tagToMap(Tag.MINEABLE_HOE, Tool.HOE);
+            tagToMap(Tag.MINEABLE_PICKAXE, Tool.PICKAXE);
+            tagToMap(Tag.MINEABLE_SHOVEL, Tool.SHOVEL);
+        } catch (NoSuchFieldError | NoClassDefFoundError ignored) {
         }
 
 

--- a/src/main/java/de/jeff_media/BestTools/BestToolsUtils.java
+++ b/src/main/java/de/jeff_media/BestTools/BestToolsUtils.java
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Objects;
 
 /**
@@ -165,9 +164,9 @@ public class BestToolsUtils {
         //usedTags.add(tag);
     }
 
-    private void printMap(HashMap<Material, Tool> toolMap) {
-        toolMap.forEach((mat, tool) -> System.out.println(String.format("%0$30s -> %s", mat.name(), tool.name())));
-    }
+    // private void printMap(HashMap<Material, Tool> toolMap) {
+    //     toolMap.forEach((mat, tool) -> System.out.println(String.format("%0$30s -> %s", mat.name(), tool.name())));
+    // }
 
     private void addToMap(@NotNull String matName, @NotNull Tool tool) {
         Material mat = Material.getMaterial(matName);

--- a/src/main/java/de/jeff_media/BestTools/Blacklist.java
+++ b/src/main/java/de/jeff_media/BestTools/Blacklist.java
@@ -1,8 +1,6 @@
 package de.jeff_media.BestTools;
 
 import net.md_5.bungee.api.chat.ClickEvent;
-import net.md_5.bungee.api.chat.ComponentBuilder;
-import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;

--- a/src/main/java/de/jeff_media/BestTools/CommandBlacklist.java
+++ b/src/main/java/de/jeff_media/BestTools/CommandBlacklist.java
@@ -51,7 +51,7 @@ public class CommandBlacklist implements CommandExecutor {
 
         ArrayList<Material> candidates = new ArrayList<>();
         ArrayList<String> errors = new ArrayList<>();
-        ArrayList<Material> alreadyAdded = new ArrayList<>();
+        // ArrayList<Material> alreadyAdded = new ArrayList<>();
         ArrayList<Material> successes = new ArrayList<>();
 
         String option;

--- a/src/main/java/de/jeff_media/BestTools/CommandBlacklist.java
+++ b/src/main/java/de/jeff_media/BestTools/CommandBlacklist.java
@@ -4,15 +4,11 @@ import org.bukkit.Material;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/de/jeff_media/BestTools/CommandDebug.java
+++ b/src/main/java/de/jeff_media/BestTools/CommandDebug.java
@@ -4,7 +4,6 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 
-import java.util.Objects;
 
 public class CommandDebug {
 
@@ -12,7 +11,7 @@ public class CommandDebug {
 
 
         if (!sender.hasPermission("besttools.debug")) {
-            sender.sendMessage(Objects.requireNonNull(command.getPermissionMessage()));
+            sender.sendMessage(ChatColor.YELLOW + main.getName() + ": you don't have permission to use this command.");
             return;
         }
         if(arg.equalsIgnoreCase("debug")) {

--- a/src/main/java/de/jeff_media/BestTools/CommandRefill.java
+++ b/src/main/java/de/jeff_media/BestTools/CommandRefill.java
@@ -1,5 +1,6 @@
 package de.jeff_media.BestTools;
 
+import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -9,7 +10,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-import java.util.Objects;
 
 public class CommandRefill implements CommandExecutor, TabCompleter {
 
@@ -26,7 +26,7 @@ public class CommandRefill implements CommandExecutor, TabCompleter {
 
         if (args.length > 0 && args[0].equalsIgnoreCase("reload")) {
             if(!sender.hasPermission("besttools.reload")) {
-                sender.sendMessage(Objects.requireNonNull(command.getPermissionMessage()));
+                sender.sendMessage(ChatColor.YELLOW + main.getName() + ": you don't have permission to use this command.");
                 return true;
             }
             CommandReload.reload(sender,command,main);

--- a/src/main/java/de/jeff_media/BestTools/CommandRefill.java
+++ b/src/main/java/de/jeff_media/BestTools/CommandRefill.java
@@ -55,8 +55,8 @@ public class CommandRefill implements CommandExecutor, TabCompleter {
 
     @Override
     public @Nullable List<String> onTabComplete(@NotNull CommandSender commandSender, @NotNull Command command, @NotNull String s,  @NotNull String[] str) {
-        final String[] args = {"toggle","on","off","preventItemBreak","hotbar","hotbarOnly"};
-        final String[] trueFalse = {"true","false"};
+        // final String[] args = {"toggle","on","off","preventItemBreak","hotbar","hotbarOnly"};
+        // final String[] trueFalse = {"true","false"};
 
 
         return null;

--- a/src/main/java/de/jeff_media/BestTools/CommandReload.java
+++ b/src/main/java/de/jeff_media/BestTools/CommandReload.java
@@ -4,15 +4,13 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 
-import java.util.Objects;
-
 public class CommandReload {
 
     static void reload(CommandSender sender, Command command, Main main) {
 
 
             if (!sender.hasPermission("besttools.reload")) {
-                sender.sendMessage(Objects.requireNonNull(command.getPermissionMessage()));
+                sender.sendMessage(ChatColor.YELLOW + main.getName() + ": you don't have permission to use this command.");
                 return;
             }
             main.load(true);

--- a/src/main/java/de/jeff_media/BestTools/EnchantmentUtils.java
+++ b/src/main/java/de/jeff_media/BestTools/EnchantmentUtils.java
@@ -10,8 +10,8 @@ public class EnchantmentUtils {
         int base = getBaseMultiplier(item);
         if(!item.hasItemMeta()) return base;
         ItemMeta meta = item.getItemMeta();
-        if(!meta.hasEnchant(Enchantment.DIG_SPEED)) return base;
-        int efficiencyLevel = meta.getEnchantLevel(Enchantment.DIG_SPEED);
+        if(!meta.hasEnchant(Enchantment.EFFICIENCY)) return base;
+        int efficiencyLevel = meta.getEnchantLevel(Enchantment.EFFICIENCY);
         return base + (efficiencyLevel * efficiencyLevel) + 1;
     }
 

--- a/src/main/java/de/jeff_media/BestTools/EnchantmentUtils.java
+++ b/src/main/java/de/jeff_media/BestTools/EnchantmentUtils.java
@@ -10,8 +10,8 @@ public class EnchantmentUtils {
         int base = getBaseMultiplier(item);
         if(!item.hasItemMeta()) return base;
         ItemMeta meta = item.getItemMeta();
-        if(!meta.hasEnchant(Enchantment.EFFICIENCY)) return base;
-        int efficiencyLevel = meta.getEnchantLevel(Enchantment.EFFICIENCY);
+        if(!meta.hasEnchant(Enchantment.DIG_SPEED)) return base;
+        int efficiencyLevel = meta.getEnchantLevel(Enchantment.DIG_SPEED);
         return base + (efficiencyLevel * efficiencyLevel) + 1;
     }
 

--- a/src/main/java/de/jeff_media/BestTools/EnchantmentUtils.java
+++ b/src/main/java/de/jeff_media/BestTools/EnchantmentUtils.java
@@ -1,5 +1,7 @@
 package de.jeff_media.BestTools;
 
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -10,8 +12,9 @@ public class EnchantmentUtils {
         int base = getBaseMultiplier(item);
         if(!item.hasItemMeta()) return base;
         ItemMeta meta = item.getItemMeta();
-        if(!meta.hasEnchant(Enchantment.EFFICIENCY)) return base;
-        int efficiencyLevel = meta.getEnchantLevel(Enchantment.EFFICIENCY);
+        Enchantment efficiency = EnchantmentUtils.getEfficiency();
+        if(!meta.hasEnchant(efficiency)) return base;
+        int efficiencyLevel = meta.getEnchantLevel(efficiency);
         return base + (efficiencyLevel * efficiencyLevel) + 1;
     }
 
@@ -25,5 +28,25 @@ public class EnchantmentUtils {
         if(n.startsWith("WOOD")) return 2;
         if(n.startsWith("GOLD")) return 12;
         return 1;
+    }
+
+    static Enchantment getEfficiency() {
+        return Registry.ENCHANTMENT.get(NamespacedKey.minecraft("efficiency"));
+    }
+
+    static Enchantment getBaneOfArthropods() {
+        return Registry.ENCHANTMENT.get(NamespacedKey.minecraft("bane_of_arthropods"));
+    }
+
+    static Enchantment getSmite() {
+        return Registry.ENCHANTMENT.get(NamespacedKey.minecraft("smite"));
+    }
+
+    static Enchantment getSharpness() {
+        return Registry.ENCHANTMENT.get(NamespacedKey.minecraft("sharpness"));
+    }
+
+    static Enchantment getSilkTouch() {
+        return Registry.ENCHANTMENT.get(NamespacedKey.minecraft("silk_touch"));
     }
 }

--- a/src/main/java/de/jeff_media/BestTools/EnchantmentUtils.java
+++ b/src/main/java/de/jeff_media/BestTools/EnchantmentUtils.java
@@ -12,7 +12,7 @@ public class EnchantmentUtils {
         int base = getBaseMultiplier(item);
         if(!item.hasItemMeta()) return base;
         ItemMeta meta = item.getItemMeta();
-        Enchantment efficiency = EnchantmentUtils.getEfficiency();
+        Enchantment efficiency = EnchantmentUtils.getEnchantment("efficiency");
         if(!meta.hasEnchant(efficiency)) return base;
         int efficiencyLevel = meta.getEnchantLevel(efficiency);
         return base + (efficiencyLevel * efficiencyLevel) + 1;
@@ -30,23 +30,7 @@ public class EnchantmentUtils {
         return 1;
     }
 
-    static Enchantment getEfficiency() {
-        return Registry.ENCHANTMENT.get(NamespacedKey.minecraft("efficiency"));
-    }
-
-    static Enchantment getBaneOfArthropods() {
-        return Registry.ENCHANTMENT.get(NamespacedKey.minecraft("bane_of_arthropods"));
-    }
-
-    static Enchantment getSmite() {
-        return Registry.ENCHANTMENT.get(NamespacedKey.minecraft("smite"));
-    }
-
-    static Enchantment getSharpness() {
-        return Registry.ENCHANTMENT.get(NamespacedKey.minecraft("sharpness"));
-    }
-
-    static Enchantment getSilkTouch() {
-        return Registry.ENCHANTMENT.get(NamespacedKey.minecraft("silk_touch"));
+    static Enchantment getEnchantment(String enchantmentKey) {
+        return Registry.ENCHANTMENT.get(NamespacedKey.minecraft(enchantmentKey));
     }
 }

--- a/src/main/java/de/jeff_media/BestTools/GUIHandler.java
+++ b/src/main/java/de/jeff_media/BestTools/GUIHandler.java
@@ -136,7 +136,7 @@ public class GUIHandler implements Listener {
         ItemStack is = createGUIItem(mat,String.format("BestTools: %s",getEnabledString(ps.isBestToolsEnabled())),main.messages.GUI_BESTTOOLS_LORE);
         if(ps.isBestToolsEnabled()) {
             ItemMeta meta = is.getItemMeta();
-            meta.addEnchant(EnchantmentUtils.getEfficiency(),5,false);
+            meta.addEnchant(EnchantmentUtils.getEnchantment("efficiency"),5,false);
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             is.setItemMeta(meta);
         }

--- a/src/main/java/de/jeff_media/BestTools/GUIHandler.java
+++ b/src/main/java/de/jeff_media/BestTools/GUIHandler.java
@@ -137,7 +137,7 @@ public class GUIHandler implements Listener {
         ItemStack is = createGUIItem(mat,String.format("BestTools: %s",getEnabledString(ps.isBestToolsEnabled())),main.messages.GUI_BESTTOOLS_LORE);
         if(ps.isBestToolsEnabled()) {
             ItemMeta meta = is.getItemMeta();
-            meta.addEnchant(Enchantment.DIG_SPEED,5,false);
+            meta.addEnchant(Enchantment.EFFICIENCY,5,false);
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             is.setItemMeta(meta);
         }

--- a/src/main/java/de/jeff_media/BestTools/GUIHandler.java
+++ b/src/main/java/de/jeff_media/BestTools/GUIHandler.java
@@ -15,7 +15,6 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 
 public class GUIHandler implements Listener {
@@ -38,21 +37,6 @@ public class GUIHandler implements Listener {
     private int coords2slot(int row, int col) {
         if (col > 9 || col < 1 || row > 6 || row < 1) throw new IllegalArgumentException();
         return (9 * (row - 1)) + col - 1;
-    }
-
-    /**
-     * Slot number to coordinates
-     * @param i slot number
-     * @return int[] coordinates where int[0] is row and int[1] is col
-     */
-    private int[] coords2slot(int i) {
-        if(i<0||i>54) throw new IllegalArgumentException();
-        int row = 0;
-        while(i>8) {
-            row++;
-            i-=8;
-        }
-        return new int[] {row,i+1};
     }
 
     private ItemStack createGUIItem(@NotNull Material mat, @Nullable String name, @Nullable String[] lores) {
@@ -153,7 +137,7 @@ public class GUIHandler implements Listener {
         ItemStack is = createGUIItem(mat,String.format("BestTools: %s",getEnabledString(ps.isBestToolsEnabled())),main.messages.GUI_BESTTOOLS_LORE);
         if(ps.isBestToolsEnabled()) {
             ItemMeta meta = is.getItemMeta();
-            meta.addEnchant(Enchantment.DIG_SPEED,5,false);
+            meta.addEnchant(Enchantment.EFFICIENCY,5,false);
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             is.setItemMeta(meta);
         }
@@ -167,7 +151,6 @@ public class GUIHandler implements Listener {
     }
 
     private void addRefillButton(PlayerSetting ps, Inventory gui) {
-        int slot = coords2slot(REFILL_SLOT[0],REFILL_SLOT[1]);
         Material mat = ps.isRefillEnabled() ? Material.MILK_BUCKET : Material.BUCKET;
         addItem(gui,2,8,mat,String.format("Refill: %s",getEnabledString(ps.isRefillEnabled())),main.messages.GUI_REFILL_LORE);
     }

--- a/src/main/java/de/jeff_media/BestTools/GUIHandler.java
+++ b/src/main/java/de/jeff_media/BestTools/GUIHandler.java
@@ -3,7 +3,6 @@ package de.jeff_media.BestTools;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
-import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -137,7 +136,7 @@ public class GUIHandler implements Listener {
         ItemStack is = createGUIItem(mat,String.format("BestTools: %s",getEnabledString(ps.isBestToolsEnabled())),main.messages.GUI_BESTTOOLS_LORE);
         if(ps.isBestToolsEnabled()) {
             ItemMeta meta = is.getItemMeta();
-            meta.addEnchant(Enchantment.EFFICIENCY,5,false);
+            meta.addEnchant(EnchantmentUtils.getEfficiency(),5,false);
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             is.setItemMeta(meta);
         }

--- a/src/main/java/de/jeff_media/BestTools/GUIHandler.java
+++ b/src/main/java/de/jeff_media/BestTools/GUIHandler.java
@@ -60,10 +60,10 @@ public class GUIHandler implements Listener {
         return i;
     }
 
-    private void addItem(Inventory gui, int row, int col, Material mat, String name, String[] lore) {
-        //String[] lores = lore.split("\\r?\\n");
-        gui.setItem(coords2slot(row, col), createGUIItem(mat, name, lore));
-    }
+    // private void addItem(Inventory gui, int row, int col, Material mat, String name, String[] lore) {
+    //     //String[] lores = lore.split("\\r?\\n");
+    //     gui.setItem(coords2slot(row, col), createGUIItem(mat, name, lore));
+    // }
 
     private void addItem(Inventory gui, int row, int col, Material mat, String name, String lore) {
         String[] lores = lore == null ? null : lore.split("\\r?\\n");
@@ -137,7 +137,7 @@ public class GUIHandler implements Listener {
         ItemStack is = createGUIItem(mat,String.format("BestTools: %s",getEnabledString(ps.isBestToolsEnabled())),main.messages.GUI_BESTTOOLS_LORE);
         if(ps.isBestToolsEnabled()) {
             ItemMeta meta = is.getItemMeta();
-            meta.addEnchant(Enchantment.EFFICIENCY,5,false);
+            meta.addEnchant(Enchantment.DIG_SPEED,5,false);
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             is.setItemMeta(meta);
         }

--- a/src/main/java/de/jeff_media/BestTools/LeavesUtils.java
+++ b/src/main/java/de/jeff_media/BestTools/LeavesUtils.java
@@ -1,7 +1,6 @@
 package de.jeff_media.BestTools;
 
 import org.bukkit.Material;
-import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 public class LeavesUtils {

--- a/src/main/java/de/jeff_media/BestTools/Main.java
+++ b/src/main/java/de/jeff_media/BestTools/Main.java
@@ -183,6 +183,7 @@ public class Main extends JavaPlugin {
     }
 
     private void registerMetrics() {
+        @SuppressWarnings("unused")
         Metrics metrics = new Metrics(this,8187);
     }
 

--- a/src/main/java/de/jeff_media/BestTools/Main.java
+++ b/src/main/java/de/jeff_media/BestTools/Main.java
@@ -3,19 +3,16 @@ package de.jeff_media.BestTools;
 import de.jeff_media.BestTools.placeholders.BestToolsPlaceholders;
 import de.jeff_media.updatechecker.UpdateChecker;
 import de.jeff_media.updatechecker.UserAgentBuilder;
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.regex.Matcher;
@@ -228,7 +225,7 @@ public class Main extends JavaPlugin {
         Matcher m = p.matcher((Bukkit.getBukkitVersion()));
         int version = -1;
         while(m.find()) {
-            if(NumberUtils.isNumber(m.group(1)))
+            if(NumberUtils.isCreatable(m.group(1)))
                 version = Integer.parseInt(m.group(1));
         }
         return version;

--- a/src/main/java/de/jeff_media/BestTools/Messages.java
+++ b/src/main/java/de/jeff_media/BestTools/Messages.java
@@ -1,11 +1,8 @@
 package de.jeff_media.BestTools;
 
-import org.apache.commons.lang.WordUtils;
+import org.apache.commons.text.WordUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-
-import java.util.List;
 
 public class Messages {
 

--- a/src/main/java/de/jeff_media/BestTools/PlayerListener.java
+++ b/src/main/java/de/jeff_media/BestTools/PlayerListener.java
@@ -1,10 +1,8 @@
 package de.jeff_media.BestTools;
 
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 public class PlayerListener implements Listener {

--- a/src/main/java/de/jeff_media/BestTools/PlayerSetting.java
+++ b/src/main/java/de/jeff_media/BestTools/PlayerSetting.java
@@ -6,11 +6,9 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.Inventory;
 import org.bukkit.persistence.PersistentDataType;
 
 import java.io.File;
-import java.io.IOException;
 
 public class PlayerSetting {
 
@@ -109,10 +107,6 @@ public class PlayerSetting {
                 this.favoriteSlot = favoriteSlot;
                 getPDCValues(player);
                 this.save();
-        }
-
-        Blacklist getBlacklist() {
-                return blacklist;
         }
 
         boolean toggleBestToolsEnabled() {

--- a/src/main/java/de/jeff_media/BestTools/PlayerSetting.java
+++ b/src/main/java/de/jeff_media/BestTools/PlayerSetting.java
@@ -6,8 +6,6 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
-import org.bukkit.persistence.PersistentDataType;
-
 import java.io.File;
 
 public class PlayerSetting {
@@ -76,9 +74,9 @@ public class PlayerSetting {
                 }
         }
 
-        private static <T,Z> Z getPdc(Player player, NamespacedKey key, PersistentDataType<T,Z> type, Z defaultValue) {
-                return player.getPersistentDataContainer().getOrDefault(key,type,defaultValue);
-        }
+        // private static <T,Z> Z getPdc(Player player, NamespacedKey key, PersistentDataType<T,Z> type, Z defaultValue) {
+        //         return player.getPersistentDataContainer().getOrDefault(key,type,defaultValue);
+        // }
 
         private void save() {
                 //System.out.println("Saving to PDC...");

--- a/src/main/java/de/jeff_media/BestTools/RefillUtils.java
+++ b/src/main/java/de/jeff_media/BestTools/RefillUtils.java
@@ -92,6 +92,7 @@ public class RefillUtils {
 
         Map<Integer,Integer> sortedSlots = MapUtils.sortByValue(slots);
         Set<Entry<Integer,Integer>> entrySet = sortedSlots.entrySet();
+        @SuppressWarnings("unchecked")
         Entry<Integer,Integer>[] entries = entrySet.toArray(new Entry[0]);
 
         return entries[entries.length-1].getKey();

--- a/src/main/java/de/jeff_media/BestTools/SwordUtils.java
+++ b/src/main/java/de/jeff_media/BestTools/SwordUtils.java
@@ -89,17 +89,17 @@ public class SwordUtils {
             Enchantment e = entry.getKey();
             int l = entry.getValue();
             // Sharpness
-            if (e.equals(Enchantment.SHARPNESS)) {
+            if (e.equals(EnchantmentUtils.getSharpness())) {
                 bonus += (0.5 * l + 0.5);
             }
             // Bane of Anthropods
-            else if(e.equals(Enchantment.BANE_OF_ARTHROPODS)) {
+            else if(e.equals(EnchantmentUtils.getBaneOfArthropods())) {
                 if(isAnthropod(enemy)) {
                     bonus += (2.5 * l);
                 }
             }
             // Smite
-            else if(e.equals(Enchantment.SMITE)) {
+            else if(e.equals(EnchantmentUtils.getSmite())) {
                 if(isUndead(enemy)) {
                     bonus += (2.5*l);
                 }

--- a/src/main/java/de/jeff_media/BestTools/SwordUtils.java
+++ b/src/main/java/de/jeff_media/BestTools/SwordUtils.java
@@ -89,17 +89,17 @@ public class SwordUtils {
             Enchantment e = entry.getKey();
             int l = entry.getValue();
             // Sharpness
-            if (e.equals(Enchantment.SHARPNESS)) {
+            if (e.equals(Enchantment.DAMAGE_ALL)) {
                 bonus += (0.5 * l + 0.5);
             }
             // Bane of Anthropods
-            else if(e.equals(Enchantment.BANE_OF_ARTHROPODS)) {
+            else if(e.equals(Enchantment.DAMAGE_ARTHROPODS)) {
                 if(isAnthropod(enemy)) {
                     bonus += (2.5 * l);
                 }
             }
             // Smite
-            else if(e.equals(Enchantment.SMITE)) {
+            else if(e.equals(Enchantment.DAMAGE_UNDEAD)) {
                 if(isUndead(enemy)) {
                     bonus += (2.5*l);
                 }

--- a/src/main/java/de/jeff_media/BestTools/SwordUtils.java
+++ b/src/main/java/de/jeff_media/BestTools/SwordUtils.java
@@ -89,17 +89,17 @@ public class SwordUtils {
             Enchantment e = entry.getKey();
             int l = entry.getValue();
             // Sharpness
-            if (e.equals(EnchantmentUtils.getSharpness())) {
+            if (e.equals(EnchantmentUtils.getEnchantment("sharpness"))) {
                 bonus += (0.5 * l + 0.5);
             }
             // Bane of Anthropods
-            else if(e.equals(EnchantmentUtils.getBaneOfArthropods())) {
+            else if(e.equals(EnchantmentUtils.getEnchantment("bane_of_arthropods"))) {
                 if(isAnthropod(enemy)) {
                     bonus += (2.5 * l);
                 }
             }
             // Smite
-            else if(e.equals(EnchantmentUtils.getSmite())) {
+            else if(e.equals(EnchantmentUtils.getEnchantment("smite"))) {
                 if(isUndead(enemy)) {
                     bonus += (2.5*l);
                 }

--- a/src/main/java/de/jeff_media/BestTools/SwordUtils.java
+++ b/src/main/java/de/jeff_media/BestTools/SwordUtils.java
@@ -89,17 +89,17 @@ public class SwordUtils {
             Enchantment e = entry.getKey();
             int l = entry.getValue();
             // Sharpness
-            if (e.equals(Enchantment.DAMAGE_ALL)) {
+            if (e.equals(Enchantment.SHARPNESS)) {
                 bonus += (0.5 * l + 0.5);
             }
             // Bane of Anthropods
-            else if(e.equals(Enchantment.DAMAGE_ARTHROPODS)) {
+            else if(e.equals(Enchantment.BANE_OF_ARTHROPODS)) {
                 if(isAnthropod(enemy)) {
                     bonus += (2.5 * l);
                 }
             }
             // Smite
-            else if(e.equals(Enchantment.DAMAGE_UNDEAD)) {
+            else if(e.equals(Enchantment.SMITE)) {
                 if(isUndead(enemy)) {
                     bonus += (2.5*l);
                 }

--- a/src/main/java/de/jeff_media/BestTools/SwordUtils.java
+++ b/src/main/java/de/jeff_media/BestTools/SwordUtils.java
@@ -2,7 +2,6 @@ package de.jeff_media.BestTools;
 
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -52,6 +51,7 @@ public class SwordUtils {
         return base + getBonus(is,enemy);
     }
 
+    @SuppressWarnings("incomplete-switch")
     static double getBaseDamage(Material mat) {
         switch (mat) {
             case IRON_AXE:
@@ -89,17 +89,17 @@ public class SwordUtils {
             Enchantment e = entry.getKey();
             int l = entry.getValue();
             // Sharpness
-            if (e.equals(Enchantment.DAMAGE_ALL)) {
+            if (e.equals(Enchantment.SHARPNESS)) {
                 bonus += (0.5 * l + 0.5);
             }
             // Bane of Anthropods
-            else if(e.equals(Enchantment.DAMAGE_ARTHROPODS)) {
+            else if(e.equals(Enchantment.BANE_OF_ARTHROPODS)) {
                 if(isAnthropod(enemy)) {
                     bonus += (2.5 * l);
                 }
             }
             // Smite
-            else if(e.equals(Enchantment.DAMAGE_UNDEAD)) {
+            else if(e.equals(Enchantment.SMITE)) {
                 if(isUndead(enemy)) {
                     bonus += (2.5*l);
                 }

--- a/src/main/java/de/jeff_media/BestTools/tags/v1_17.java
+++ b/src/main/java/de/jeff_media/BestTools/tags/v1_17.java
@@ -9,13 +9,13 @@ public class v1_17 {
 
     public static Collection<Material> getPickaxeMaterials() {
         //org.bukkit.Tag
-        Tag<Material> [] tags = new Tag[]{
+        List<Tag<Material>> tags = Arrays.asList(
                 Tag.STONE_BRICKS, Tag.STONE_PRESSURE_PLATES,
                 Tag.BASE_STONE_NETHER, Tag.BASE_STONE_OVERWORLD,
                 Tag.REDSTONE_ORES, Tag.COAL_ORES, Tag.COPPER_ORES,
                 Tag.DIAMOND_ORES, Tag.EMERALD_ORES, Tag.GOLD_ORES,
                 Tag.IRON_ORES, Tag.LAPIS_ORES
-        };
+        );
 
         Set<Material> list = new HashSet<>();
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 main: de.jeff_media.BestTools.Main
 name: BestTools
 version: ${project.version}
-api-version: "1.13"
+api-version: "1.16"
 description: Automatically chooses the best tool when breaking blocks
 author: mfnalex
 #website: https://www.chestsort.de


### PR DESCRIPTION
I made a lot of changes that clean up the code base, but shouldn't change the function of the plugin. If you don't like all the changes, the only changes that actually matter for 1.21 are adding the mace to the weapons and adding a specific case for copper trapdoors.

I tested dozens of materials with and without tool enchantments (including those that profit from silk touch), automatic refills, and switching for hostile mob attacks in both 1.21 and 1.16.5. I also tested sculk, bamboo, and mangrove roots, as noted in the 2.2.2 and 2.2.3 release notes (even though those versions aren't in the codebase).

* clean up warnings
* update to Spigot 1.21 API
* add mace
* update dependencies
* resolve deprecations
* allow getMcVersion to match 1.21
* move BestToolsUtils.init() call into constructor
* add mineable/ tag catchalls as futureproofing (if there are issues, we may have to move these earlier in the order to allow overrides)
* abstract enchantments with Bukkit Registry
* increase minimum API 1.16 due to MorePersistentDataTypes requirements (according to bStats, no one's running this <1.16.5 and it doesn't actually work <1.14 due to the use of PersistentDataContainer)
* Spigot 1.16 can and should run under Java 11, so target the build accordingly
* clean up pom file
* add a few comments