### PR TITLE
bugfix/bamboo sapling is toolless

### DIFF
--- a/src/main/java/de/jeff_media/BestTools/BestToolsUtils.java
+++ b/src/main/java/de/jeff_media/BestTools/BestToolsUtils.java
@@ -338,7 +338,6 @@ public class BestToolsUtils {
         addToMap("ANCIENT_DEBRIS", Tool.PICKAXE);
         addToMap("ANDESITE", Tool.PICKAXE);
         addToMap("BAMBOO", Tool.AXE);
-        addToMap("BAMBOO_SAPLING", Tool.AXE);
         addToMap("BASALT", Tool.PICKAXE);
         addToMap("BIRCH_BUTTON", Tool.AXE);
         addToMap("BIRCH_FENCE", Tool.AXE);


### PR DESCRIPTION
Bamboo saplings don't break faster with an axe and aren't part of the #mineable/axe tag.